### PR TITLE
Replace single environment tag on public ip resource with a merge block of default and extra tags

### DIFF
--- a/r-api-management.tf
+++ b/r-api-management.tf
@@ -6,9 +6,7 @@ resource "azurerm_public_ip" "apim" {
   sku                 = "Standard"
   domain_name_label   = lower(local.apim_name)
 
-  tags = {
-    environment = var.environment
-  }
+  tags = merge(local.default_tags, var.extra_tags)
 }
 
 resource "azurerm_api_management" "apim" {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23431

### Change description
- Public IP resource was being creatd with just the environment tag, replacing this block with same pattern as other resources to ensure all resources created by APIM TF get tagged properly and tags required by DTSPO-23431 are assigned.
 
### Testing done
TF plan: https://dev.azure.com/hmcts-cpp/cpp-apps/_build/results?buildId=92462&view=logs&j=fc4b4ecc-4d80-5b68-35db-ecb09f019833&t=5fb644f2-67fc-57d2-2613-669118b26655

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
